### PR TITLE
Save token in storage and send with header

### DIFF
--- a/doc-control-app-react/src/components/Authentication/Authentication.js
+++ b/doc-control-app-react/src/components/Authentication/Authentication.js
@@ -18,6 +18,7 @@ export default class Authentication extends Component {
     //sessionStorage.clear("user");
     this.setState({ isLogged: false });
     localStorage.clear("user");
+    localStorage.clear("accessToken");
   };
   logout = () => {
     return <div onClick={this.onClickLogoutHandler}>Log out</div>;

--- a/doc-control-app-react/src/components/Authentication/LoginContainer.js
+++ b/doc-control-app-react/src/components/Authentication/LoginContainer.js
@@ -73,15 +73,14 @@ export default class LoginContainer extends Component {
     ///userData.append("password", this.state.password);
     Axios.post("http://localhost:8081/api/auth/signin", data)
       .then(res => {
-        Axios.get("http://localhost:8081/api/users/me", {
-          headers: { Authorization: `Bearer ${res.data.accessToken}` }
-        })
+        localStorage.setItem(
+          "accessToken",
+          JSON.stringify(res.data.accessToken)
+        );
+        Axios.defaults.headers.Authorization = `Bearer ${JSON.parse(localStorage.getItem("accessToken"))}`;
+        Axios.get("http://localhost:8081/api/users/me")
           .then(ress => {
             localStorage.setItem("user", JSON.stringify(ress.data));
-            localStorage.setItem(
-              "accessToken",
-              JSON.stringify(res.data.accessToken)
-            );
             this.props.setLoggedState();
             console.log(ress.data);
           })


### PR DESCRIPTION
Added feature to save token in local storage and send with every axios request.
Reset local storage accessToken on logout.